### PR TITLE
Add plugins data to config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -9,13 +9,14 @@
     </author>
     <content src="index.html" />
     <plugin name="cordova-plugin-whitelist" version="1" />
+    <plugin name="cordova-plugin-geolocation" spec="^1.0.1" />
+    <plugin name="com.pylonproducts.wifiwizard" spec="https://github.com/simlay/WifiWizard" />
     <access origin="*" />
     <access origin="*.us-west-2.compute.amazonaws.com" />
     <allow-navigation href="*.us-west-2.compute.amazonaws.com" />
     <allow-navigation href="http://*/*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
-
     <platform name="android">
         <allow-intent href="market:*" />
     </platform>


### PR DESCRIPTION
New in Cordova 5\* is the ability to add cordova plugins into the config file
No longer is needed to have the corodva plugin add commands for your clones
It will be auto installed when you add the platform.

This can be auto-generated at the initial addition using the --save switch
cordova plugin add --save cordova-plugin-geolocation
